### PR TITLE
Add Spanish localization and documentation

### DIFF
--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -1,0 +1,57 @@
+# Eclipse Enhance
+Este complemento para NVDA ofrece un soporte mejorado mientras se trabaja con el entorno de desarrollo Eclipse.
+
+## Características del complemento:
+### Características principales:
+* Reproduce sonidos diferentes mientras usas el atajo **ctrl+. (punto)** de Eclipse para identificar si hay seleccionada una advertencia o un error.
+* Reproduce sonidos diferentes cuando pulsas **ctrl+s** para indicar si el archivo guardado contiene errores o advertencias.
+* Anuncia la conmutación de puntos de ruptura (breakpoints) mientras se pulsa **ctrl+shift+b**.
+
+### Características adicionales de Braille:
+* Muestra mensajes braille si el archivo guardado contiene errores o advertencias;
+* Soluciona un problema que impide usar la tecla de retroceso de la pantalla braille para ir a la línea anterior
+
+### Características de voz adicionales:
+* Anuncia la línea actual mientras te desplazas con las teclas de depuración
+* Anuncia la línea actual cuando pulsas ctrl+. y el cursor se mueve.
+* Anuncia la línea actual al pulsar ctrl+shift+flechas arriba y abajo para saltar al método anterior o al siguiente
+* Anuncia la línea actual al pulsar ctrl+shift+p teniendo seleccionado un paréntesis: este atajo salta al paréntesis correspondiente de apertura o de cierre
+
+## Configuración de Eclipse
+Para aprovechar todas las ventajas que te ofrece este complemento, tienes que configurar Eclipse para que resalte las advertencias y los errores en lugar de subrayarlos.
+Para hacerlo, sigue estos pasos:
+
+* Abre el entorno Eclipse
+* Abre el menú Window (alt+w)
+* Elige el elemento "Preferences"
+* Navega a la presentación en árbol
+* Navega a General, Editors, Text Editors, Anotations
+* Pulsa tabulador para moverte a la lista de anotaciones
+
+En cada anotación puedes elegir:
+
+* Tres casillas de verificación (Vertical ruler, Overview ruler y Text As)
+* Un cuadro combinado que indica cómo se presenta la anotación en el texto (disponible cuando se ha marcado la casilla Text As).
+
+Configura las anotaciones de la siguiente manera::
+
+* **Breackpoints**: casilla Text As marcada, y opción "highlighted" del cuadro combinado.
+* **Errors**: casilla Text As marcada, y opción “highlighted” del cuadro combinado.
+* **Info**: casilla Text As desmarcada
+* **Matching tags**: casilla Text As desmarcada
+* **Occurrences**: casilla Text As desmarcada
+* **Search Results**: casilla Text As desmarcada
+* **Warnings**: casilla Text As marcada, y opción “highlighted” del cuadro combinado.
+
+
+## Derechos de copia de los sonidos
+Los sonidos usados para indicar advertencias y errores están cubiertos por la licencia Creative Commons.
+
+* [Visita esta página para el sonido de error](https://www.freesound.org/people/Autistic%20Lucario/sounds/142608/)
+* [Visita esta página para el sonido de advertencia](https://www.freesound.org/people/ecfike/sounds/135125/)
+
+
+## Autores:
+* Alberto Zanella
+* Alessandro Albano
+

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the 'eclipseEnhance' package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 'eclipseEnhance' '0.2'\n"
+"Report-Msgid-Bugs-To: 'nvda-translations@freelists.org'\n"
+"POT-Creation-Date: 2018-12-18 12:47+0100\n"
+"PO-Revision-Date: 2018-12-18 12:50+0100\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.2\n"
+"Last-Translator: Iván Novegil <ivan.novegil.cancelas@gmail.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: es\n"
+
+#. Add-on summary, usually the user visible name of the addon.
+#. Translators: Summary for this add-on to be shown on installation and add-on information.
+#: buildVars.py:17
+msgid "Eclipse Enhance"
+msgstr "Eclipse Enhance"
+
+#. Add-on description
+#. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
+#: buildVars.py:20
+msgid ""
+"Enhance the speech and braille support while using the Eclipse IDE "
+"reportings errors and warnings."
+msgstr ""
+"Mejora el soporte de habla y braille al usar el entorno de "
+"desarrollo  integrado Eclipse reportando errores y advertencias."


### PR DESCRIPTION
This is a markdown adaptation of the translation by @jmdaweb uploaded to the nvda.es website at https://nvda.es/2018/10/12/eclipse-enhance Translation's contents have been left as they were. It also includes translations for manifest.