### PR TITLE
Fix dbeaver autocomplete on Windows 11

### DIFF
--- a/addon/appModules/eclipse.py
+++ b/addon/appModules/eclipse.py
@@ -8,8 +8,14 @@ OLD_BEHAVIOR = False
 
 if OLD_BEHAVIOR :
 	from . import eclipse_legacy as base_eclipse
+	AutocompletionListItem = None
 else :
 	from nvdaBuiltin.appModules import eclipse as base_eclipse
+	try:
+		from nvdaBuiltin.appModules.eclipse import AutocompletionListItem
+	except ImportError:
+		AutocompletionListItem = None
+
 from scriptHandler import script
 import addonHandler
 import eventHandler
@@ -268,7 +274,19 @@ class AppModule(base_eclipse.AppModule):
 		if obj.windowClassName == "SWT_Window0" and obj.role == controlTypes.Role.EDITABLETEXT:
 			clsList.remove(base_eclipse.EclipseTextArea)
 			clsList.insert(0, EclipseTextArea)
-
+		# Autocompletion items are placed outside the main eclipse window
+		if (
+				AutocompletionListItem is not None and
+				AutocompletionListItem not in clsList and
+				obj.role == controlTypes.Role.LISTITEM
+				and obj.parent.parent.parent.role == controlTypes.Role.DIALOG
+				and obj.parent.parent.parent.simpleParent == api.getDesktopObject()
+				and obj.parent.parent.parent.parent.simpleNext.role in (
+					controlTypes.Role.BUTTON,
+					controlTypes.Role.TOGGLEBUTTON
+				)
+			):
+				clsList.insert(0, AutocompletionListItem)
 
 	
 	def play_suggestions(self) :

--- a/buildVars.py
+++ b/buildVars.py
@@ -37,7 +37,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion" : "2021.1",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2023.1",
+	"addon_lastTestedNVDAVersion" : "2024.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
fixes #14 .
This PR is a backport of the PR at https://github.com/nvaccess/nvda/pull/16417 , but for older versions of NVDA and accounting for the legacy mode of the addon. With this PR, Users that cannot upgrade to a newer version of NVDA can use autocomplete on Windows 11.